### PR TITLE
Repair logic for defining nginx dns resolvers

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -66,7 +66,7 @@ class NginxConfig
         nameservers << md[1]
       end
     end
-    nameservers << [DEFAULT[:resolver]] unless nameservers.empty?
+    nameservers << [DEFAULT[:resolver]] if nameservers.empty?
     json["resolver"] = nameservers.join(" ")
 
     json.each do |key, value|


### PR DESCRIPTION
Previous to this change, the default resolver of 8.8.8.8 was always added to the list of nameservers, unless it was empty.  The correct logic is to add the default resolver only if the list of nameservers is empty.